### PR TITLE
Propagate last-line WARNING and ERROR log messages to check message

### DIFF
--- a/check_unattended_upgrades
+++ b/check_unattended_upgrades
@@ -411,15 +411,17 @@ if [ -z "$LOG_TEXT" ]; then
 	LOG_TEXT="$(zcat $LATEST_COMPRESSED_LOG)"
 fi
 
+LAST_LOG_WARNING_ERROR=$(echo "$LOG_TEXT" | tail -n 1 | grep -E ' (WARNING|ERROR) ')
+
 # added -s check because it returns error on an empty file
-if [ -n "$LOG_TEXT" ] && [ -z "$(echo "$LOG_TEXT" | tail -n 1 | grep -v ' ERROR ')" ]; then
-	echo "CRITICAL - The last line in the log file is an ERROR message."
+if [ -n "$LOG_TEXT" ] && [ ! -z "$(echo "$LAST_LOG_WARNING_ERROR" | grep ' ERROR ')" ]; then
+	echo "CRITICAL - The last line in the log file is an ERROR message.\n${LAST_LOG_WARNING_ERROR}"
 	exit $STATE_CRITICAL
 fi
 
 # added -s check because it returns error on an empty file
-if [ -n "$LOG_TEXT" ] && [ -z "$(echo "$LOG_TEXT" | tail -n 1 | grep -v ' WARNING ')" ]; then
-	echo "WARNING - The last line in the log file is a WARNING message."
+if [ -n "$LOG_TEXT" ] && [ ! -z "$(echo "$LAST_LOG_WARNING_ERROR" | grep ' WARNING ')" ]; then
+	echo "WARNING - The last line in the log file is a WARNING message.\n${LAST_LOG_WARNING_ERROR}"
 	exit $STATE_WARNING
 fi
 

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -25,6 +25,7 @@ setup() {
 	run ./check_unattended_upgrades_patched
 	[ "$status" -eq 2 ]
 	[ "${lines[0]}" = 'CRITICAL - The last line in the log file is an ERROR message.' ]
+	[ "${lines[1]}" = '2019-01-12 14:35:58,860 ERROR Cache has broken packages, exiting' ]
 }
 
 @test "WARNING last log line WARNING" {
@@ -32,6 +33,7 @@ setup() {
 	run ./check_unattended_upgrades_patched
 	[ "$status" -eq 1 ]
 	[ "${lines[0]}" = 'WARNING - The last line in the log file is a WARNING message.' ]
+	[ "${lines[1]}" = '2019-01-12 14:35:58,860 WARNING lol' ]
 }
 
 @test "CRITICAL log file doesn't exist. Insufficient permissions" {


### PR DESCRIPTION
Dear @Josef-Friedrich,

first things first: Thanks a stack for conceiving and maintaining this excellent check program. We were amazed about its test suite, this is nothing short of transformational for a check program and not found very often.

### Status quo
We are using the `Unattended-Upgrade::Automatic-Reboot` option, which, when armed, leaves such a message as the last log line in `/var/log/unattended-upgrades/unattended-upgrades.log`:
```
WARNING Shutdown msg: b"Shutdown scheduled for Sun 2022-03-20 04:00:00 CET, use 'shutdown -c' to cancel."
```

`check_unattended_upgrades`, in turn, will report `WARNING - The last line in the log file is a WARNING message.`, which is perfectly fine.


### Improvement
For us, it would be sweet to actually be able to see the content of the message within the check text. This patch implements it and we hope you will like it. Below, you can find two screenshots how this will look like, both in Icinga Web and in aNag.

With kind regards,
Andreas.

/cc @tonkenfo

#### Icinga Web
![image](https://user-images.githubusercontent.com/453543/159141790-5d31576e-e8c4-4741-a8fc-1d88aa8efac5.png)

#### aNag
![image](https://user-images.githubusercontent.com/453543/159141829-1b845ed1-8d93-4b15-af55-ebffb31dffa2.png)

