### PR TITLE
Variable names changed, bugs fixed and added more information to "verbose"

### DIFF
--- a/check_unattended_upgrades.py
+++ b/check_unattended_upgrades.py
@@ -784,8 +784,8 @@ class ChecksCollection:
         if opts.anacron:
             self.checks += [AnacronResource(), AnacronContext()]
 
-        if opts.custom_repos:
-            for repo in opts.custom_repos:
+        if opts.custom_repo:
+            for repo in opts.custom_repo:
                 self.checks += [CustomRepoResource(repo), CustomRepoContext(repo)]
 
         if opts.dry_run:

--- a/check_unattended_upgrades.py
+++ b/check_unattended_upgrades.py
@@ -574,7 +574,7 @@ class DryRunContext(nagiosplugin.Context):
         if metric.value == 0:
             return self.result_cls(
                 nagiosplugin.Ok,
-                metric=metric
+                metric=metric,
                 hint="unattended-upgrades --dry-run exits with a zero status (OK).",
             )
         else:

--- a/check_unattended_upgrades.py
+++ b/check_unattended_upgrades.py
@@ -41,7 +41,7 @@ class OptionContainer:
     anacron: bool
     autoclean: str | None
     critical: int
-    custom_repo: list[str] | None
+    custom_repos: list[str] | None
     download: str | None
     dry_run: bool
     enable: str | None
@@ -174,7 +174,7 @@ def get_argparser() -> argparse.ArgumentParser:
         "-p",
         "--repo",
         "--custom-repo",
-        dest="custom_repo",
+        dest="custom_repos",
         action='append',
         help="Check if 'Unattended-upgrades' is configured to include the "
         "specified custom repository.",
@@ -784,8 +784,8 @@ class ChecksCollection:
         if opts.anacron:
             self.checks += [AnacronResource(), AnacronContext()]
 
-        if opts.custom_repo:
-            for repo in opts.custom_repo:
+        if opts.custom_repos:
+            for repo in opts.custom_repos:
                 self.checks += [CustomRepoResource(repo), CustomRepoContext(repo)]
 
         if opts.dry_run:


### PR DESCRIPTION
I fetched again and corrected earlier errors on my end, then clarified a distinction between the array and its individual strings by missing custom_repos and a plural-s.

But before I did it again uniformly without - that had gotten into me in an earlier pull request and couldn't work that way at all. Now I have it in one commit as it was before, then in a second commit with the plural, so you can choose to accept or reject that and the code still runs.

I also added an output string to OK messages for --verbose, because I like to see it right in the frontend, what exactly I'm monitoring, because I don't know that well after a few months. This is the third commit.

The fourth is the correction of a comma I found while testing. :)